### PR TITLE
Update status_led.rst

### DIFF
--- a/components/light/status_led.rst
+++ b/components/light/status_led.rst
@@ -1,19 +1,19 @@
-Status Led Light
+Status LED Light
 ================
 
 .. seo::
-    :description: Instructions for setting up a Status Led shared also as binary ON/OFF light in ESPHome.
+    :description: Instructions for setting up a Status LED shared also as binary ON/OFF light in ESPHome.
     :image: led-on.png
 
-The ``status_led`` light platform allows to share a single led for indicating the status of
+The ``status_led`` light platform allows to share a single LED for indicating the status of
 the device (when on error/warning state) or as binary light (when on OK state). 
-This is useful for devices with only one led available.
+This is useful for devices with only one LED available.
 
 It provides the combined functionality of :doc:`status_led component </components/status_led>` and a 
 :doc:`binary light component </components/light/binary>` over a single shared GPIO led. 
 
-When the device is on error/warning state, the function of ``status_led`` will take precedence and control the blinking of the led.
-When the device is in OK state, the led will be restored to the state of the ``binary light`` function and can be controlled as such.
+When the device is on error/warning state, the function of ``status_led`` will take precedence and control the blinking of the LED.
+When the device is in OK state, the LED will be restored to the state of the ``binary light`` function and can be controlled as such.
 
 .. code-block:: yaml
 

--- a/components/status_led.rst
+++ b/components/status_led.rst
@@ -23,7 +23,7 @@ the device. Specifically, it will:
 
 .. note::
 
-    If your device has a single led that needs to be shared use  :doc:`status_led light platform </components/light/status_led>` instead.
+    If your device has a single LED that needs to be shared use  :doc:`status_led light platform </components/light/status_led>` instead.
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
Amended status_led.rst to use a consistent case for *LED* when compared with the bulk of https://esphome.io/components/status_led.html. The latter uses an uppercase *LED* rather than the lowercase previously used in this page. 

**Related issue (if applicable):** fixes <link to issue>
n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
n/a

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
