### PR TITLE
Update airthings_ble.rst

### DIFF
--- a/components/sensor/airthings_ble.rst
+++ b/components/sensor/airthings_ble.rst
@@ -26,12 +26,12 @@ To find out your device's MAC address, add the following to your ESPHome configu
 
 The device will then listen for nearby devices, and display a message like this one:
 
-``
-[D][airthings_ble:019]: 
-Found AirThings device Serial: 123456789 (MAC: 01:02:03:04:05:06)
-``
+.. code-block:: text
 
-Once the device is found, **remove the ``airthings_ble:`` device tracker** from your configuration and take note of the device MAC address, and use it when configuring a sensor below.
+    [D][airthings_ble:019]: 
+    Found AirThings device Serial: 123456789 (MAC: 01:02:03:04:05:06)
+
+Once the device is found, remove the ``airthings_ble`` device tracker from your configuration and take note of the device MAC address, and use it when configuring a sensor below.
 
 Supported Devices
 -----------------
@@ -46,6 +46,8 @@ AirThings Wave Plus tracks radon (24h and long term), airborne chemicals, CO2, t
     :width: 60.0%
 
 Configuration example:
+*********
+
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Improved formatting and hierarchy of document

## Description:
 - Made configuration example into a heading.
 - Fixed the example message format
 - Removed the bold style from 'remove the airthings_ble...' clause, as it was breaking the backticks.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
